### PR TITLE
Habit entry update

### DIFF
--- a/app/graphql/mutations/create_habit_entry.rb
+++ b/app/graphql/mutations/create_habit_entry.rb
@@ -7,10 +7,7 @@ module Mutations
       habits = params.map { |habit| Hash habit }
       begin
         user = User.first
-        habits.each do |habit|
-          user.habit_entries.create!(habit_id: habit[:id], status: 1)
-        end
-        HabitEntry.create_neglected(user, habits)
+        HabitEntry.create_entries(user, habits)
 
         { user: user }
 

--- a/app/models/habit_entry.rb
+++ b/app/models/habit_entry.rb
@@ -2,14 +2,36 @@ class HabitEntry < ApplicationRecord
   belongs_to :user
   belongs_to :habit
 
-  def self.create_neglected(user, habits)
-    habit_ids = habits.map { |habits| habits[:id] }
+  def self.create_neglected(user, habit_ids)
     neglected = Habit.where.not(id: habit_ids)
     neglected.each do |habit|
       user.habit_entries.create!(habit_id: habit.id, status: 0)
     end
   end
 
+  def self.create_entries(user, habits)
+    destroy_today_entries(user)
+    habit_ids = habits.map { |habits| habits[:id] }
+
+    habit_ids.each do |habit_ids|
+      user.habit_entries.create!(habit_id: habit_ids, status: 1)
+    end
+
+    #gets array of habit ids where there are no entries for today
+    neglected = Habit.select('habits.id')
+      .left_joins(:habit_entries)
+      .where(habit_entries: {user_id: user.id})
+      .where('habit_entries.created_at > ?', Date.today)
+      .distinct.pluck('habits.id')
+
+    create_neglected(user, neglected)
+  end
+
+  def self.destroy_today_entries(user)
+    where('created_at > ?', Date.today)
+      .where(user_id: user.id)
+      .destroy_all
+  end
   scope :completed, -> {
     where(status: 1)
   }

--- a/app/models/habit_entry.rb
+++ b/app/models/habit_entry.rb
@@ -17,14 +17,7 @@ class HabitEntry < ApplicationRecord
       user.habit_entries.create!(habit_id: habit_ids, status: 1)
     end
 
-    #gets array of habit ids where there are no entries for today
-    neglected = Habit.select('habits.id')
-      .left_joins(:habit_entries)
-      .where(habit_entries: {user_id: user.id})
-      .where('habit_entries.created_at > ?', Date.today)
-      .distinct.pluck('habits.id')
-
-    create_neglected(user, neglected)
+    create_neglected(user, habit_ids)
   end
 
   def self.destroy_today_entries(user)

--- a/app/models/habit_entry.rb
+++ b/app/models/habit_entry.rb
@@ -14,7 +14,7 @@ class HabitEntry < ApplicationRecord
   end
 
   def self.destroy_today_entries(user)
-    where('created_at > ?', Date.today)
+    current_day
       .where(user_id: user.id)
       .destroy_all
   end
@@ -25,6 +25,7 @@ class HabitEntry < ApplicationRecord
       user.habit_entries.create!(habit_id: habit.id, status: 0)
     end
   end
+
   scope :completed, -> {
     where(status: 1)
   }

--- a/app/models/habit_entry.rb
+++ b/app/models/habit_entry.rb
@@ -2,28 +2,28 @@ class HabitEntry < ApplicationRecord
   belongs_to :user
   belongs_to :habit
 
-  def self.create_neglected(user, habit_ids)
-    neglected = Habit.where.not(id: habit_ids)
-    neglected.each do |habit|
-      user.habit_entries.create!(habit_id: habit.id, status: 0)
-    end
-  end
-
   def self.create_entries(user, habits)
     destroy_today_entries(user)
-    habit_ids = habits.map { |habits| habits[:id] }
+    completed_ids = habits.map { |habits| habits[:id] }
 
-    habit_ids.each do |habit_ids|
-      user.habit_entries.create!(habit_id: habit_ids, status: 1)
+    completed_ids.each do |habit_id|
+      user.habit_entries.create!(habit_id: habit_id, status: 1)
     end
 
-    create_neglected(user, habit_ids)
+    create_neglected(user, completed_ids)
   end
 
   def self.destroy_today_entries(user)
     where('created_at > ?', Date.today)
       .where(user_id: user.id)
       .destroy_all
+  end
+
+  def self.create_neglected(user, completed_ids)
+    neglected = Habit.where.not(id: completed_ids)
+    neglected.each do |habit|
+      user.habit_entries.create!(habit_id: habit.id, status: 0)
+    end
   end
   scope :completed, -> {
     where(status: 1)

--- a/spec/models/habit_entry_spec.rb
+++ b/spec/models/habit_entry_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe HabitEntry, type: :model do
       expect(@user.habit_entries.count).to eq(15)
       expect(HabitEntry.last.status).to eq(0)
     end
-    
+
     it 'does not duplicate neglected habits' do
       create(:habit_entry, user_id: @user.id, habit_id: @habit.id, status: 0)
 
@@ -53,6 +53,15 @@ RSpec.describe HabitEntry, type: :model do
 
       expect(@user.habit_entries.count).to eq(16)
     end
+
+    it 'can destroy all entries for today' do
+      create(:habit_entry, user_id: @user.id, habit_id: @habit.id, created_at: Date.today - 1)
+      create_list(:habit_entry, 3, user_id: @user.id, habit_id: @habit.id)
+
+      HabitEntry.destroy_today_entries(@user)
+
+      expect(@user.habit_entries.count).to eq(1)
+    end
   end
 
   describe 'daily completed' do
@@ -71,5 +80,4 @@ RSpec.describe HabitEntry, type: :model do
       expect(user.habit_entries.daily_completed).to eq(completed_today.map(&:habit_id))
     end
   end
-
 end

--- a/spec/models/habit_entry_spec.rb
+++ b/spec/models/habit_entry_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe HabitEntry, type: :model do
     end
 
     it 'creates habit entries for neglected habits' do
-      HabitEntry.create_neglected(@user, [{id: @habit.id}])
+      HabitEntry.create_neglected(@user, [@habit.id])
 
       expect(@user.habit_entries.count).to eq(15)
       expect(HabitEntry.last.status).to eq(0)
@@ -24,13 +24,13 @@ RSpec.describe HabitEntry, type: :model do
     it 'does not duplicate neglected habits' do
       create(:habit_entry, user_id: @user.id, habit_id: @habit.id, status: 0)
 
-      HabitEntry.create_neglected(@user, [])
+      HabitEntry.create_entries(@user, [])
 
       expect(@user.habit_entries.count).to eq(15)
     end
 
     it 'creates habit entries for completed habits' do
-      HabitEntry.create_entries(@user, [{id: @habit.id}, {id: 2}])
+      HabitEntry.create_entries(@user, [{id: @habit.id}])
 
       expect(@user.habit_entries.count).to eq(15)
       expect(@habit.habit_entries.first.status).to eq(1)

--- a/spec/models/habit_entry_spec.rb
+++ b/spec/models/habit_entry_spec.rb
@@ -20,6 +20,39 @@ RSpec.describe HabitEntry, type: :model do
       expect(@user.habit_entries.count).to eq(15)
       expect(HabitEntry.last.status).to eq(0)
     end
+    
+    it 'does not duplicate neglected habits' do
+      create(:habit_entry, user_id: @user.id, habit_id: @habit.id, status: 0)
+
+      HabitEntry.create_neglected(@user, [])
+
+      expect(@user.habit_entries.count).to eq(15)
+    end
+
+    it 'creates habit entries for completed habits' do
+      HabitEntry.create_entries(@user, [{id: @habit.id}, {id: 2}])
+
+      expect(@user.habit_entries.count).to eq(15)
+      expect(@habit.habit_entries.first.status).to eq(1)
+      expect(HabitEntry.last.status).to eq(0)
+    end
+
+    it 'can update habit entries' do
+      HabitEntry.create_neglected(@user, [])
+
+      HabitEntry.create_entries(@user, [{id: @habit.id}])
+
+      expect(@user.habit_entries.count).to eq(15)
+      expect(@habit.habit_entries.first.status).to eq(1)
+    end
+
+    it 'is date sensitive' do
+      create(:habit_entry, user_id: @user.id, habit_id: @habit.id, created_at: Date.today - 1)
+
+      HabitEntry.create_entries(@user, [{id: @habit.id}])
+
+      expect(@user.habit_entries.count).to eq(16)
+    end
   end
 
   describe 'daily completed' do
@@ -38,4 +71,5 @@ RSpec.describe HabitEntry, type: :model do
       expect(user.habit_entries.daily_completed).to eq(completed_today.map(&:habit_id))
     end
   end
+
 end

--- a/spec/requests/graphql/mutations/create_habit_entry_spec.rb
+++ b/spec/requests/graphql/mutations/create_habit_entry_spec.rb
@@ -31,7 +31,7 @@ describe 'create habit entry' do
     post '/graphql', params: { query: update_query }
 
     expect(@user.habit_entries.count).to eq(Habit.all.count)
-    expect(@user.habit_entries[1].status).to eq(1)
+    expect(@user.habit_entries[0].status).to eq(1)
     expect(@habit.habit_entries.first.status).to eq(1)
   end
 

--- a/spec/requests/graphql/mutations/create_habit_entry_spec.rb
+++ b/spec/requests/graphql/mutations/create_habit_entry_spec.rb
@@ -4,7 +4,7 @@ describe 'create habit entry' do
 
   before :each do
     @user = create(:user)
-    @habit = create(:habit)
+    @habit = create(:habit, id: 1)
     create(:habit, id: 7)
     create(:habit, id: 13)
   end
@@ -23,6 +23,16 @@ describe 'create habit entry' do
     parsed = JSON.parse(response.body, symbolize_names: true)
 
     expect(parsed).to have_key(:errors)
+  end
+
+  it 'can update habit entries' do
+    post '/graphql', params: { query: query }
+
+    post '/graphql', params: { query: update_query }
+
+    expect(@user.habit_entries.count).to eq(Habit.all.count)
+    expect(@user.habit_entries[1].status).to eq(1)
+    expect(@habit.habit_entries.first.status).to eq(1)
   end
 
   def query
@@ -47,6 +57,22 @@ describe 'create habit entry' do
       createHabitEntry(
         input: {
           haha_evil_query
+        }
+      ) {
+        user {
+          id
+        }
+      }
+    }
+    GQL
+  end
+
+  def update_query
+    <<~GQL
+    mutation {
+      createHabitEntry(
+        input: {
+          params: [{id: 1}]
         }
       ) {
         user {


### PR DESCRIPTION
# Change Log

- Closes # 35

## What I did:

- Made it so that with every create habit entry request every habit entry (for that day) is updated with the details of the request.

## Things to consider:

- The current method destroys all habit entries for that day, then recreates them either completed or uncompleted.
- Is day sensitive (no destroying previous day's entries).
- If no request for a day is made, no entries will be created.
- No rebase for this branch, as it is directly off of main. 

## Test coverage

- [x] 100% Model Testing
- [] 100% Request Testing

If below 100%, what still needs testing:

- Daily mood and daily habits in user_type
