### PR TITLE
Add error catch for no selected daily mood error

### DIFF
--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -40,7 +40,11 @@ module Types
     end
 
     def daily_mood
-      object.daily_mood
+      mood = object.daily_mood
+
+      raise GraphQL::ExecutionError.new('No Mood Selected') unless mood.is_a?(Mood)
+
+      mood
     end
 
     def daily_habits


### PR DESCRIPTION
# Change Log

- Closes #

## What I did:

- Add error catch for graphql error when querying for a daily mood when no mood qualifies
- Returns error message and whatever else was in the query instead of exploding

## Things to consider:

-

## Test coverage

- [] 100% Model Testing
- [] 100% Request Testing

If below 100%, what still needs testing:

-
